### PR TITLE
Add DB pool lifecycle hooks

### DIFF
--- a/PORTING_PROGRESS.md
+++ b/PORTING_PROGRESS.md
@@ -91,3 +91,7 @@ implementation. Each endpoint is marked ✅ if it has a matching counterpart in
 | PATCH | /v1/user/variable/update | ✅ |
 | GET | /v1/variabletypes/list | ✅ |
 
+
+## Notes
+- Queries now support asyncpg via automatic placeholder conversion from `?` to `$n` in `portal_db.py`.
+- The API now opens the database connection pool on FastAPI startup and closes it on shutdown.

--- a/portalwebapi.py
+++ b/portalwebapi.py
@@ -25,6 +25,18 @@ app = FastAPI()
 
 db = PortalDB()
 
+
+@app.on_event("startup")
+async def startup() -> None:
+    """Open the shared database connection pool."""
+    await db.connect()
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    """Close the shared database connection pool."""
+    await db.close()
+
 @app.delete("/v1/customers/delete")
 async def v1_customers_delete(customernumber: Optional[str] = None, customer_id: Optional[int] = None):
     """Delete a customer by number or id.
@@ -2625,6 +2637,7 @@ async def v1_sensorunits_data(
     sensordb = PortalDB(
         dsn=f"dbi:Pg:dbname={sensor_db_name};host=localhost;port=5432"
     )
+    await sensordb.connect()
     try:
         query = (
             "SELECT probenumber, sequencenumber, value, timestamp "


### PR DESCRIPTION
## Summary
- connect to PortalDB on FastAPI startup and close on shutdown
- ensure per-customer PortalDB instances are connected before queries
- document database lifecycle steps

## Testing
- `python3 -m py_compile portal_db.py portalwebapi.py`


------
https://chatgpt.com/codex/tasks/task_e_685a9520bfb8832f8219e255b37bfd06